### PR TITLE
Fix non continuous pahts

### DIFF
--- a/examples/gpx.rs
+++ b/examples/gpx.rs
@@ -162,7 +162,9 @@ fn main() -> Result<(), Error> {
             acc
         });
 
-    let paths = down_size(paths, resolution);
+
+    //let paths = down_size(paths, resolution);
+
     let (min_lat, min_lon, max_lat, max_lon) = get_boundaries(&paths);
 
     let lat_adjustment: f32 = -{
@@ -186,10 +188,11 @@ fn main() -> Result<(), Error> {
 
     let paths: loempia::Paths = to_paths(paths);
     let plot = Plot::new(paths);
+    svg::save("/tmp/image.svg", &plot.preview()).unwrap();
 
-    let serial_path = path::Path::new("/dev/ttyACM0");
-    let mut driver = Driver::open(serial_path)?;
+    //let serial_path = path::Path::new("/dev/ttyACM0");
+    //let mut driver = Driver::open(serial_path)?;
 
-    driver.plot(&plot)?;
+    //driver.plot(&plot)?;
     Ok(())
 }

--- a/examples/square.rs
+++ b/examples/square.rs
@@ -1,11 +1,17 @@
-use loempia::{Driver, Error, Plot};
+use loempia::{point::Coordinate, Driver, Error, Plot};
 use std::path::Path;
 
 fn main() -> Result<(), Error> {
     let serial_path = Path::new("/dev/ttyACM0");
     let mut driver = Driver::open(serial_path)?;
 
-    let path = vec![(0, 0), (1000, 0), (1000, 1000), (0, 1000), (0, 0)];
+    let path = vec![
+        Coordinate::new(0, 0),
+        Coordinate::new(1000, 0),
+        Coordinate::new(1000, 1000),
+        Coordinate::new(0, 1000),
+        Coordinate::new(0, 0),
+    ];
     let plot = Plot::from_path(path)?;
 
     driver.plot(&plot)?;

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -1,3 +1,4 @@
+use loempia::point::Coordinate;
 use loempia::{Driver, Error, Plot};
 use std::path::Path;
 
@@ -6,16 +7,20 @@ fn main() -> Result<(), Error> {
     let mut driver = Driver::open(serial_path)?;
 
     let path = vec![
-        (1000, 1000),
-        (2000, 0000),
-        (3000, 1000),
-        (4000, 0000),
-        (0000, 0000),
-        (2000, 2000),
-        (3000, 1000),
-        (1000, 1000),
+        Coordinate::new(1000, 1000),
+        Coordinate::new(2000, 0000),
+        Coordinate::new(3000, 1000),
+        Coordinate::new(4000, 0000),
+        Coordinate::new(0000, 0000),
+        Coordinate::new(2000, 2000),
+        Coordinate::new(3000, 1000),
+        Coordinate::new(1000, 1000),
     ];
-    let plot = Plot::from_path(path)?;
+    let plot = {
+        let path = path;
+        let paths = loempia::Paths::new(vec![path])?;
+        Plot::new(paths)
+    };
 
     driver.plot(&plot)?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,8 +226,6 @@ impl Plot {
             doc = doc.add(path);
         }
 
-        //data = data.close();
-
         let rect = SVG_Path::new()
             .set("fill", "none")
             .set("stroke", "black")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@ use std::time::Duration;
 use thiserror::Error;
 
 use svg::node::element::path::Data;
-use svg::node::element::{Path as SVG_Path, Rectangle};
+use svg::node::element::Path as SVG_Path;
 use svg::Document;
 
 use serial_core::SerialDevice;
 
 pub mod point;
-use point::{Absolute, Coordinate, Relative};
+use point::{Coordinate, Relative};
 
 /// A series of connected `Point`s form a `Path`.
 pub type Path = Vec<point::Coordinate<point::Absolute>>;
@@ -208,8 +208,7 @@ impl Plot {
 
         let strokes: Strokes = (&self.paths).try_into().unwrap();
 
-        let mut doc = Document::new()
-            .set("viewBox", (min_x, min_y, max_x - min_x, max_y - min_y));
+        let mut doc = Document::new().set("viewBox", (min_x, min_y, max_x - min_x, max_y - min_y));
 
         for stroke in strokes.0 {
             let mut data = Data::new();
@@ -225,7 +224,6 @@ impl Plot {
                 .set("d", data);
 
             doc = doc.add(path);
-
         }
 
         //data = data.close();
@@ -246,7 +244,6 @@ impl Plot {
             );
 
         doc.add(rect)
-
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,22 +13,14 @@ use svg::Document;
 
 use serial_core::SerialDevice;
 
-//pub type Relative = 1;
-
-//pub type Coordinate<T> {
-    //x: i32,
-    //y: i32,
-//};
-
-
-/// A `Point` is a coordinate on a 2D cartesian plane. Multi
-pub type Point = (i32, i32);
+pub mod point;
+use point::{Absolute, Coordinate, Relative};
 
 /// A series of connected `Point`s form a `Path`.
-pub type Path = Vec<Point>;
+pub type Path = Vec<point::Coordinate<point::Absolute>>;
 
 pub struct Paths {
-    paths: Vec<Path>,
+    pub paths: Vec<Path>,
 }
 
 impl Paths {
@@ -52,11 +44,11 @@ impl Paths {
 
 /// Get the boundaries of the boundaries of a series of paths. The function is generic
 /// over the type coordinate type
-pub fn get_boundaries<T: PartialOrd + Copy>(paths: &Vec<Vec<(T, T)>>) -> (T, T, T, T) {
+pub fn get_boundaries(paths: &Paths) -> (i32, i32, i32, i32) {
     let (mut min_x, mut min_y, mut max_x, mut max_y) = (None, None, None, None);
 
-    paths.iter().for_each(|path| {
-        path.iter().for_each(|(x, y)| {
+    paths.paths.iter().for_each(|path| {
+        path.iter().for_each(|Coordinate { x, y, .. }| {
             _ = min_x.get_or_insert(x);
             _ = max_x.get_or_insert(x);
 
@@ -90,11 +82,8 @@ pub fn get_boundaries<T: PartialOrd + Copy>(paths: &Vec<Vec<(T, T)>>) -> (T, T, 
     )
 }
 
-// A `Vector` represents a movement in an x and y direction.
-type Vector = (i32, i32);
-
-impl From<&Vector> for Command {
-    fn from(value: &Vector) -> Self {
+impl From<&Coordinate<Relative>> for Command {
+    fn from(value: &Coordinate<Relative>) -> Self {
         fn movement_on_x_axis(delta_x: i32) -> (i32, i32) {
             (delta_x, -delta_x)
         }
@@ -102,10 +91,10 @@ impl From<&Vector> for Command {
         fn movement_on_y_axis(delta_y: i32) -> (i32, i32) {
             (-delta_y, -delta_y)
         }
-        let (delta_x, delta_y) = value;
+        let (delta_x, delta_y) = (value.x, value.y);
 
-        let (x1, y1) = movement_on_x_axis(*delta_x);
-        let (x2, y2) = movement_on_y_axis(*delta_y);
+        let (x1, y1) = movement_on_x_axis(delta_x);
+        let (x2, y2) = movement_on_y_axis(delta_y);
 
         Command::SM {
             duration: 1000,
@@ -117,30 +106,30 @@ impl From<&Vector> for Command {
 
 /// A `Stroke` is a collection of `Vector`s.
 #[derive(PartialEq, Debug)]
-struct Stroke(pub Vec<Vector>);
-
-impl ops::Deref for Stroke {
-    type Target = Vec<Vector>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+struct Stroke {
+    start: point::Coordinate<point::Absolute>,
+    path: Vec<point::Coordinate<point::Relative>>,
+    end: point::Coordinate<point::Absolute>,
 }
 
 impl TryFrom<&Path> for Stroke {
     type Error = Error;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        let vectors: Result<Vec<Vector>, Self::Error>  = path
+        let stroke: Result<Vec<point::Coordinate<point::Relative>>, Self::Error>  = path
             .windows(2)
             .map(|points| match points {
-                [(x1, y1), (x2, y2)] => Ok((x2 - x1, y2 - y1)),
+                [p1, p2] => Ok(Coordinate::new(p2.x - p1.x, p2.y - p1.y)),
                 _ => Err(Error::ConversionError(format!("Failed to convert `Path` to `Stroke`. Given `Path` contains {:?} `Point`s, but requires at least 2 `Point`s.", path.len())))
             })
             .collect();
 
-        let vectors = vectors?;
-        Ok(Stroke(vectors))
+        let stroke = stroke?;
+        Ok(Stroke {
+            start: *path.first().expect(""),
+            end: *path.last().expect(""),
+            path: stroke,
+        })
     }
 }
 
@@ -169,30 +158,42 @@ impl TryFrom<&Paths> for Strokes {
 fn convert_to_series_of_commands(strokes: Strokes) -> Vec<Vec<Command>> {
     strokes
         .iter()
-        .map(|stroke| stroke.iter().map(Command::from).collect())
+        .map(|stroke| {
+            let mut cmds: Vec<Command> = vec![];
+            // Ugly work around to move to first point of stroke.
+            let start: Coordinate<Relative> = Coordinate::new(stroke.start.x, stroke.start.y);
+
+            // Move to first point.
+            cmds.push(Command::from(&start));
+            // Lower the pen.
+            cmds.push(Command::Any("SP,1".to_string()));
+
+            let x: Vec<Command> = stroke.path.iter().map(Command::from).collect();
+            for command in x {
+                cmds.push(command);
+            }
+
+            // Raise the pen.
+            cmds.push(Command::Any("SP,0".to_string()));
+
+            // Ugly work around to move to home.
+            let home: Coordinate<Relative> = Coordinate::new(-stroke.end.x, -stroke.end.y);
+
+            // Move to home.
+            cmds.push(Command::from(&home));
+            cmds
+        })
         .collect()
-}
-
-// Return the distance between end of a path and the start of the subsequent path.
-fn spacers(paths: &Paths) -> Vec<(i32, i32)> {
-    paths.paths.windows(2).map(|window| {
-        let end  = *window[0].last().unwrap();
-        let start = *window[1].first().unwrap();
-
-        (start.0 - end.0, start.1 - end.1)
-    }).collect()
 }
 
 pub struct Plot {
     paths: Paths,
-    start: Point,
 }
 
 impl Plot {
     /// Create a new `Plot`.
     pub fn new(paths: Paths) -> Self {
-        let start = paths.paths[0][0];
-        Plot { paths, start }
+        Plot { paths }
     }
 
     /// Create a new `Plot` using a single `Path`.
@@ -203,30 +204,31 @@ impl Plot {
 
     /// Create SVG preview `Plot` as SVG.
     pub fn preview(&self) -> Document {
-        let (min_x, min_y, max_x, max_y) = get_boundaries(&self.paths.paths);
-        let mut data = Data::new().move_to(self.start);
+        let (min_x, min_y, max_x, max_y) = get_boundaries(&self.paths);
 
         let strokes: Strokes = (&self.paths).try_into().unwrap();
-        let binding = spacers(&self.paths);
-        let mut spacers = binding.iter();
+
+        let mut doc = Document::new()
+            .set("viewBox", (min_x, min_y, max_x - min_x, max_y - min_y));
 
         for stroke in strokes.0 {
-            for point in &stroke.0 {
-                data = data.line_by(*point);
+            let mut data = Data::new();
+            data = data.move_to((stroke.start.x, stroke.start.y));
+            for point in &stroke.path {
+                data = data.line_by((point.x, point.y));
             }
 
-            if let Some(move_by) = spacers.next() {
-                data = data.move_by(*move_by);
-            };
+            let path = SVG_Path::new()
+                .set("fill", "none")
+                .set("stroke", "black")
+                .set("stroke-width", 10)
+                .set("d", data);
+
+            doc = doc.add(path);
+
         }
 
-        data = data.close();
-
-        let path = SVG_Path::new()
-            .set("fill", "none")
-            .set("stroke", "black")
-            .set("stroke-width", 10)
-            .set("d", data);
+        //data = data.close();
 
         let rect = SVG_Path::new()
             .set("fill", "none")
@@ -243,12 +245,8 @@ impl Plot {
                     .line_to((0, 0)),
             );
 
-        Document::new()
-            .set("viewBox", (min_x, min_y, max_x - min_x, max_y - min_y))
-            //.set("viewBox", (-1000, -1000, 30300, 21000))
-            //.set("viewBox", (0, 0, 100, 100))
-            .add(path)
-            .add(rect)
+        doc.add(rect)
+
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,0 +1,24 @@
+use std::marker::PhantomData;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Relative;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Absolute;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Coordinate<T> {
+    pub x: i32,
+    pub y: i32,
+    _type: PhantomData<T>,
+}
+
+impl<T> Coordinate<T> {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self {
+            x,
+            y,
+            _type: Default::default(),
+        }
+    }
+}


### PR DESCRIPTION
Until now, distinct path were rendered as continues paths.
A bug caused a path to start where the previous path ended. 

When plotting a map with roads, this issue became really present. 

This commit replaces `Point` and `Vector` with `Coordinate<T>`. `T` is either `Absolute` or `Relative`.

A `Path` is now a series of absolute coordinates. This `Path` is turned into a `Stroke`, which has an absolute two coordinates
indicating the start and end of the stroke. The coordinates between start and end are relative to each other.

After a `Stroke` has been plotted, the plotter head moves back to home, before moving to the start of the subsequent
`Stroke`.

Fixes #8 